### PR TITLE
Do not error on unset varible

### DIFF
--- a/kinect2_registration/CMakeLists.txt
+++ b/kinect2_registration/CMakeLists.txt
@@ -101,7 +101,7 @@ if(DEPTH_REG_OPENCL)
 endif()
 
 add_library(kinect2_registration SHARED src/kinect2_registration.cpp ${MODULES})
-message(${MODULE_LIBS})
+message("${MODULE_LIBS}")
 ament_target_dependencies(kinect2_registration
   rclcpp
   std_msgs


### PR DESCRIPTION
See #3. This fixes an error raised during compilation ("message called with incorrect number of arguments"). MODULE_LIBS will remain unset if DEPTH_REG_OPENCL is not used which is still considered normal behaviour.

Let me know if you would prefer this to error even if the CPU reg method is used